### PR TITLE
Apply margin only for right

### DIFF
--- a/app/components/He4rt.tsx
+++ b/app/components/He4rt.tsx
@@ -9,7 +9,7 @@ export default function He4rt() {
         className='absolute top-0 right-0 w-full max-w-[70%] md:max-w-[50%]'
       />
       <header
-        className='container relative mx-auto flex w-full flex-col items-center justify-between gap-6 px-10 py-24 lg:flex-row lg:py-[196px]'
+        className='container relative mx-auto flex w-full flex-col items-center justify-between gap-6 px-4 md:px-10 py-24 lg:flex-row lg:py-[196px]'
         id='inicio'
       >
         <div className='flex w-full flex-col lg:w-1/2 lg:max-w-[544px]'>

--- a/app/components/He4rt.tsx
+++ b/app/components/He4rt.tsx
@@ -9,7 +9,7 @@ export default function He4rt() {
         className='absolute top-0 right-0 w-full max-w-[70%] md:max-w-[50%]'
       />
       <header
-        className='container relative mx-auto flex w-full flex-col items-center justify-between gap-6 px-4 md:px-10 py-24 lg:flex-row lg:py-[196px]'
+        className='container relative mx-auto flex w-full flex-col items-center justify-between gap-6 pr-10 pl-4 md:px-10 py-24 lg:flex-row lg:py-[196px]'
         id='inicio'
       >
         <div className='flex w-full flex-col lg:w-1/2 lg:max-w-[544px]'>

--- a/app/components/Projects.tsx
+++ b/app/components/Projects.tsx
@@ -47,7 +47,7 @@ const Projects = () => {
       <Slider {...settings}>
         {data.projects.map((project) => (
           <div key={project.username}>
-            <div className='m-4 flex flex-1 flex-col overflow-hidden rounded-lg shadow-md'>
+            <div className='mr-3 flex flex-1 flex-col overflow-hidden rounded-lg shadow-md'>
               <div className='flex flex-1 flex-row items-center justify-center gap-4 bg-gradient-to-tr from-[#782BF1] to-[#C92BF1] p-4 text-white'>
                 <img
                   src={project.avatar}

--- a/app/components/Projects.tsx
+++ b/app/components/Projects.tsx
@@ -47,7 +47,7 @@ const Projects = () => {
       <Slider {...settings}>
         {data.projects.map((project) => (
           <div key={project.username}>
-            <div className='mr-3 mb-4 flex flex-1 flex-col overflow-hidden rounded-lg shadow-md'>
+            <div className='mr-3 mb-4 lg:mr-8 flex flex-1 flex-col overflow-hidden rounded-lg shadow-md'>
               <div className='flex flex-1 flex-row items-center justify-center gap-4 bg-gradient-to-tr from-[#782BF1] to-[#C92BF1] p-4 text-white'>
                 <img
                   src={project.avatar}

--- a/app/components/Projects.tsx
+++ b/app/components/Projects.tsx
@@ -43,11 +43,11 @@ const Projects = () => {
   };
 
   return (
-    <div className='w-full md:w-[715px]'>
+    <div className='mt-4 w-full md:w-[715px]'>
       <Slider {...settings}>
         {data.projects.map((project) => (
           <div key={project.username}>
-            <div className='mr-3 flex flex-1 flex-col overflow-hidden rounded-lg shadow-md'>
+            <div className='mr-3 mb-4 flex flex-1 flex-col overflow-hidden rounded-lg shadow-md'>
               <div className='flex flex-1 flex-row items-center justify-center gap-4 bg-gradient-to-tr from-[#782BF1] to-[#C92BF1] p-4 text-white'>
                 <img
                   src={project.avatar}


### PR DESCRIPTION
Se eu entendi corretamente, isso deveria resolver o alinhamento incorreto do carrossel no mobile. Consegui distribuir melhor as margens para mantermos os espaçamentos verticais e direcionar o horizontal apenas em um lado.

PS: O card acabou uns 20px de largura, como temos uma configuração para mostrar um slide por vez acredito que não será um problema, mas caso seja interessante aplicar um `max-width` ou algo parecido, super OK.

## Mobile (414 x 736)

Before | After
:---------------:|:---------------:
![image](https://user-images.githubusercontent.com/86631177/213019847-a6afdb7d-b7ab-400c-96ad-8a2a4f2fc35e.png) |![image](https://user-images.githubusercontent.com/86631177/213021330-3660308b-56a2-4f67-ba94-28d87ab95779.png)

## Desktop(1139 x 270)

Before | After
:---------------:|:---------------:
![image](https://user-images.githubusercontent.com/86631177/213019953-c898316f-d3ec-495b-8a3e-7c4689a0c4ba.png) |![image](https://user-images.githubusercontent.com/86631177/213022918-517cea1b-9619-46e3-b843-566a9ec3a4e2.png)

Solves #27 